### PR TITLE
XD-218 document custom certificates

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -91,7 +91,7 @@ NOTE: Note that the version used in `docs.image` *must* be the same as used in `
 [source,yaml,subs="attributes"]
 ----
   docs:
-    image: xillio/xillio-engine-docs:2.6.10
+    image: xillio/xillio-engine-docs:2.7.1
     deploy:
       labels:
         traefik.port: 80
@@ -122,7 +122,7 @@ CAUTION: Copying the `REPLACE_ME` values without changing them is a critical sec
     - 15672:15672
 
   scriptagent:
-    image: xillio/xillio-engine-script-agent:2.6.10
+    image: xillio/xillio-engine-script-agent:2.7.1
     deploy:
       replicas: 3
     environment:
@@ -180,7 +180,7 @@ execute:
 ----
 $ docker service ls
 ID                  NAME                MODE                REPLICAS            IMAGE                         PORTS
-vwfmazh43t67        xillio_engine       replicated          2/2                 xillio/xillio-engine:2.6.10
+vwfmazh43t67        xillio_engine       replicated          2/2                 xillio/xillio-engine:2.7.1
 ub4o6wdbqzhm        xillio_postgres     replicated          1/1                 postgres:10.5
 pu7zepl225lo        xillio_proxy        replicated          1/1                 traefik:1.6                   *:80->80/tcp, *:8080->8080/tcp
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -77,8 +77,9 @@ With the stack file configured, you can either <<configure-additional-features>>
 [#configure-additional-features]
 == Configure Additional Features
 
-As described in <<architecture>>, there are more services which expose additional features. These features are not
-present by default and need to be enabled. This requires additional configuration.
+This section will show more features that can be configured on top of the aforementioned minimal configuration.
+Furthermore, as described in <<architecture>>, there are more services which expose additional features as well.
+These features are not present by default and need to be enabled. This requires additional configuration.
 
 === Reference Documentation
 
@@ -99,6 +100,39 @@ NOTE: Note that the version used in `docs.image` *must* be the same as used in `
 ----
 
 After deployment the documentation can be found on the path `/docs`.
+
+=== Installing self-signed certificates
+
+In order to ensure secure connections in a private cloud, you might need to trust self-signed certificates issued by
+a private Certificate Authority. In order to do so, you can install these certificates in the trust store of the JVM
+by doing the following.
+
+To let the container install self-signed certificates, you need to make sure that these certificates are exposed in the
+directory indicated by the `CERT_PATH` environment variable in the Docker container before the service starts. This
+path defaults to `/cert`. You can add your certificates in that directory by mounting a Docker volume as follows:
+
+.stack.yml (service truncated)
+[source,yaml,subs="attributes"]
+----
+  engine:
+    image: xillio/xillio-engine:2.7.1
+    volumes:
+    - /my/path/to/cert/directory:/cert
+----
+
+If you want to install the certificates in a different directory, you can override the `CERT_PATH` variable in the
+`environment` section of the stack file as follows:
+
+.stack.yml (service truncated)
+[source,yaml,subs="attributes"]
+----
+  engine:
+    image: xillio/xillio-engine:2.7.1
+    volumes:
+    - /my/path/to/cert/directory:/custom/cert/path
+    environment:
+      CERT_PATH=/custom/cert/path
+----
 
 === Content Scripts
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -134,6 +134,18 @@ If you want to install the certificates in a different directory, you can overri
       CERT_PATH=/custom/cert/path
 ----
 
+If the certificates were successfully installed in the trust store of the JVM, a log message will be visible early in
+the logs of the container. Note that this is only exposed on the container's logs, not that of the Stack service
+(possibly consisting of multiple container).
+
+[source,bash]
+----
+trying to import /cert/readme.md
+keytool error: java.lang.Exception: Input not an X.509 certificate
+trying to import /cert/my-certificate.ca-bundle
+Certificate was added to keystore
+----
+
 === Content Scripts
 
 In order to also add the feature to use the <<content-script-agent>>, we need a few more services. In order to let

--- a/docs/stack.yml
+++ b/docs/stack.yml
@@ -19,7 +19,7 @@ services:
         - node.role == manager
 
   engine:
-    image: xillio/xillio-engine:2.6.10
+    image: xillio/xillio-engine:2.7.1
     deploy:
       replicas: 2
       labels:


### PR DESCRIPTION
This PR adds documentation on how to trust self-signed certificates for the Xillio API. It also updates the Xillio services to use the most recent version. 

Fixes [XD-218](https://xillio.atlassian.net/browse/XD-218)
