### PR TITLE
XD-154 - Update Xillio API version

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -111,7 +111,7 @@ NOTE: Note that the version used in `docs.image` *must* be the same as used in `
 [source,yaml,subs="attributes"]
 ----
   docs:
-    image: xillio/xillio-engine-docs:2.9.5
+    image: xillio/xillio-engine-docs:2.10.2
     deploy:
       labels:
         traefik.port: 80
@@ -135,7 +135,7 @@ path defaults to `/cert`. You can add your certificates in that directory by mou
 [source,yaml,subs="attributes"]
 ----
   engine:
-    image: xillio/xillio-engine:2.9.5
+    image: xillio/xillio-engine:2.10.2
     volumes:
     - /my/path/to/cert/directory:/cert
 ----
@@ -147,7 +147,7 @@ If you want to install the certificates in a different directory, you can overri
 [source,yaml,subs="attributes"]
 ----
   engine:
-    image: xillio/xillio-engine:2.9.5
+    image: xillio/xillio-engine:2.10.2
     volumes:
     - /my/path/to/cert/directory:/custom/cert/path
     environment:
@@ -188,7 +188,7 @@ CAUTION: Copying the `REPLACE_ME` values without changing them is a critical sec
     - 15672:15672
 
   scriptagent:
-    image: xillio/xillio-engine-script-agent:2.9.5
+    image: xillio/xillio-engine-script-agent:2.10.2
     deploy:
       replicas: 3
     environment:
@@ -246,7 +246,7 @@ execute:
 ----
 $ docker service ls
 ID                  NAME                MODE                REPLICAS            IMAGE                         PORTS
-vwfmazh43t67        xillio_engine       replicated          2/2                 xillio/xillio-engine:2.9.5
+vwfmazh43t67        xillio_engine       replicated          2/2                 xillio/xillio-engine:2.10.2
 ub4o6wdbqzhm        xillio_postgres     replicated          1/1                 postgres:10.5
 pu7zepl225lo        xillio_proxy        replicated          1/1                 traefik:1.6                   *:80->80/tcp, *:8080->8080/tcp
 

--- a/docs/stack.yml
+++ b/docs/stack.yml
@@ -19,7 +19,7 @@ services:
         - node.role == manager
 
   engine:
-    image: xillio/xillio-engine:2.9.5
+    image: xillio/xillio-engine:2.10.2
     deploy:
       replicas: 2
       labels:


### PR DESCRIPTION
As part of release 2.10.0 to 2.10.2 we have upgraded major dependencies in our `xillio-engine` image (see https://github.com/xillio/xillio-api-release-notes/pull/2 respectively). Therefore, we need to update this installation manual to use this new version of Xillio API. 

Fixes [XD-154](https://xillio.atlassian.net/browse/XD-154)